### PR TITLE
Installed sqlite gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.3'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+gem 'sqlite3', '1.4.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ DEPENDENCIES
   semantic-ui-sass
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
+  sqlite3 (= 1.4.1)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Attempt to fix error from Heroku

```
To see why this extension failed to compile, please check the mkmf.log which can
       be found here:
       
       /tmp/build_278672bc3bbf5db76ef4f175f0fff747/vendor/bundle/ruby/2.6.0/extensions/x86_64-linux/2.6.0/sqlite3-1.4.1/mkmf.log
       
       extconf failed, exit code 1
       
       Gem files will remain installed in
       /tmp/build_278672bc3bbf5db76ef4f175f0fff747/vendor/bundle/ruby/2.6.0/gems/sqlite3-1.4.1
       for inspection.
       Results logged to
       /tmp/build_278672bc3bbf5db76ef4f175f0fff747/vendor/bundle/ruby/2.6.0/extensions/x86_64-linux/2.6.0/sqlite3-1.4.1/gem_make.out
       
       An error occurred while installing sqlite3 (1.4.1), and Bundler cannot continue.
       Make sure that `gem install sqlite3 -v '1.4.1' --source 'https://rubygems.org/'`
       succeeds before bundling.
       
       In Gemfile:
         sqlite3
 !
 !     Failed to install gems via Bundler.
 !     Detected sqlite3 gem which is not supported on Heroku:
 !     https://devcenter.heroku.com/articles/sqlite3
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```
